### PR TITLE
Fix mixin problem

### DIFF
--- a/feagen/feature_generator.py
+++ b/feagen/feature_generator.py
@@ -1,4 +1,5 @@
 import os.path
+import inspect
 
 import h5py
 from mkdir_p import mkdir_p
@@ -9,6 +10,10 @@ class FeatureGeneratorType(type):
 
     def __new__(mcs, clsname, bases, dct):
         # pylint: disable=protected-access
+        cls = super(FeatureGeneratorType, mcs).__new__(
+            mcs, clsname, bases, dct)
+        attrs = inspect.getmembers(
+            cls, lambda a: hasattr(a, '_feagen_data_type'))
 
         func_set_dict = {
             'features': {},
@@ -16,22 +21,19 @@ class FeatureGeneratorType(type):
         }
 
         # register the data name
-        for attr_key, val in six.viewitems(dct):
-            if not hasattr(val, '_feagen_data_type'):
-                continue
-            set_name = val._feagen_data_type
+        for attr_key, attr_val in attrs:
+            set_name = attr_val._feagen_data_type
             func_dict = func_set_dict[set_name]
-            for key in val._feagen_will_generate_keys:
+            for key in attr_val._feagen_will_generate_keys:
                 if key in func_dict:
                     raise ValueError("duplicated {} {} in {} and {}".format(
                         set_name, key, func_dict[key], attr_key))
                 func_dict[key] = attr_key
 
-        dct['_feature_func_dict'] = func_set_dict['features']
-        dct['_intermediate_data_func_dict'] = func_set_dict['intermediate_data']
+        cls._feature_func_dict = func_set_dict['features']
+        cls._intermediate_data_func_dict = func_set_dict['intermediate_data']
 
-        return super(FeatureGeneratorType, mcs).__new__(
-            mcs, clsname, bases, dct)
+        return cls
 
 
 class FeatureGenerator(six.with_metaclass(FeatureGeneratorType, object)):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ long_description = ("See `github <https://github.com/ianlini/feagen>`_ "
 
 setup(
     name='feagen',
-    version="0.3.0",
+    version="0.3.1",
     description=description,
     long_description=long_description,
     author='ianlini',


### PR DESCRIPTION
The original `FeatureGenerator` is not allowed to be used with other mixin classes because the metaclass can only get the new attribute in `__new__`, that is, it won't know the methods it is inheriting.
Therefore, we change to:
1. init the class in the metaclass first and get `cls`
2. inspect the `cls`'s class members to get all the methods
3. build the function dicts
4. append the function dicts to the `cls`