### PR TITLE
Pandas hdf bundle (resolved #48)

### DIFF
--- a/examples/lifetime_prediction/tests.py
+++ b/examples/lifetime_prediction/tests.py
@@ -16,8 +16,8 @@ def test_generate_lifetime_features():
     with open(join(config_dir, 'bundle_config.yml')) as fp:
         bundle_config = yaml.load(fp)
 
-    h5py_hdf_path = mkstemp(suffix=".h5")[1]
-    data_bundles_dir = mkdtemp()
+    h5py_hdf_path = mkstemp(prefix="feagen_test_h5py_", suffix=".h5")[1]
+    data_bundles_dir = mkdtemp(prefix="feagen_test_bundle_")
     data_bundle_hdf_path = join(data_bundles_dir, 'default.h5')
 
     global_config['data_bundles_dir'] = data_bundles_dir

--- a/feagen/bundling.py
+++ b/feagen/bundling.py
@@ -1,9 +1,9 @@
+import os
 from past.builtins import basestring
 
 import numpy as np
 import pandas as pd
 import h5py
-import h5sparse
 import six
 from bistiming import IterTimer, SimpleTimer
 
@@ -29,7 +29,7 @@ def get_data_keys_from_structure(structure):
 
 class DataBundlerMixin(object):
 
-    def fill_concat_data(self, dset_name, data_keys, bundle_h5_group,
+    def fill_concat_data(self, data_bundle_hdf_path, dset_name, data_keys,
                          buffer_size=int(1e+9)):
         data_shapes = []
         for data_key in data_keys:
@@ -49,11 +49,11 @@ class DataBundlerMixin(object):
         n_cols = sum(shape[1] for shape in data_shapes)
         concat_shape = (n_rows, n_cols)
 
-        bundle_h5_group.create_dataset(dset_name, shape=concat_shape,
-                                       dtype=np.float32)
+        h5f = h5py.File(data_bundle_hdf_path)
+        dset = h5f.create_dataset(dset_name, shape=concat_shape,
+                                  dtype=np.float32)
 
         data_d = 0
-        dset = bundle_h5_group[dset_name]
         for data_i, (data_key, data_shape) in enumerate(
                 zip(data_keys, data_shapes)):
             data = self.get(data_key)
@@ -78,33 +78,37 @@ class DataBundlerMixin(object):
 
             data_d += data_shape[1]
 
+        h5f.close()
+
     def bundle(self, structure, data_bundle_hdf_path, buffer_size=int(1e+9),
                structure_config=None):
         if structure_config is None:
             structure_config = {}
 
-        def _bundle_data(structure, structure_config, bundle_h5_group):
+        def _bundle_data(structure, structure_config, group_name):
             for key, val in six.viewitems(structure):
                 config = structure_config.get(key, {})
                 if isinstance(val, basestring):
-                    self.get_handler(val).bundle(val, bundle_h5_group, key)
+                    (self.get_handler(val)
+                     .bundle(val, data_bundle_hdf_path, group_name + "/" + key))
                 elif isinstance(val, list):
                     if config.get('concat', False):
-                        self.fill_concat_data(key, val, bundle_h5_group,
-                                              buffer_size)
+                        self.fill_concat_data(
+                            data_bundle_hdf_path, group_name + "/" + key,
+                            val, buffer_size)
                     else:
-                        new_group = bundle_h5_group.create_group(key)
                         for data_key in val:
                             (self.get_handler(data_key)
-                             .bundle(data_key, new_group))
+                             .bundle(data_key, data_bundle_hdf_path,
+                                     "%s/%s/%s" % (group_name, key, data_key)))
                 elif isinstance(val, dict):
-                    new_group = bundle_h5_group.create_group(key)
                     _bundle_data(structure[key], structure_config.get(key, {}),
-                                 new_group)
+                                 group_name + "/" + key)
                 else:
                     raise TypeError("The bundle structure only support "
                                     "dict, list and str.")
 
-        with h5py.File(data_bundle_hdf_path, 'w') as data_bundle_h5f, \
-                SimpleTimer("Bundling data"):
-            _bundle_data(structure, structure_config, data_bundle_h5f)
+        if os.path.isfile(data_bundle_hdf_path):
+            os.remove(data_bundle_hdf_path)
+        with SimpleTimer("Bundling data"):
+            _bundle_data(structure, structure_config, "/")

--- a/feagen/bundling.py
+++ b/feagen/bundling.py
@@ -87,12 +87,7 @@ class DataBundlerMixin(object):
             for key, val in six.viewitems(structure):
                 config = structure_config.get(key, {})
                 if isinstance(val, basestring):
-                    data = self.get(val)
-                    if isinstance(data, h5sparse.Dataset):
-                        h5_group = h5sparse.Group(bundle_h5_group)
-                    else:
-                        h5_group = bundle_h5_group
-                    h5_group.create_dataset(key, data=data)
+                    self.get_handler(val).bundle(val, bundle_h5_group, key)
                 elif isinstance(val, list):
                     if config.get('concat', False):
                         self.fill_concat_data(key, val, bundle_h5_group,
@@ -100,12 +95,8 @@ class DataBundlerMixin(object):
                     else:
                         new_group = bundle_h5_group.create_group(key)
                         for data_key in val:
-                            data = self.get(data_key)
-                            if isinstance(data, h5sparse.Dataset):
-                                h5sparse.Group(new_group).create_dataset(
-                                    data_key, data=data)
-                            else:
-                                new_group.create_dataset(data_key, data=data)
+                            (self.get_handler(data_key)
+                             .bundle(data_key, new_group))
                 elif isinstance(val, dict):
                     new_group = bundle_h5_group.create_group(key)
                     _bundle_data(structure[key], structure_config.get(key, {}),

--- a/feagen/data_generator.py
+++ b/feagen/data_generator.py
@@ -86,9 +86,13 @@ class DataGenerator(six.with_metaclass(FeatureGeneratorType, DataBundlerMixin)):
                                      lacked_handlers_set))
         self._handlers = handlers
 
-    def get(self, key):
+    def get_handler(self, key):
         node_attr = self._dag.get_node_attr(key)
         handler = self._handlers[node_attr['handler']]
+        return handler
+
+    def get(self, key):
+        handler = self.get_handler(key)
         data = handler.get(key)
         return data
 

--- a/feagen/tests/test_feature_generator.py
+++ b/feagen/tests/test_feature_generator.py
@@ -36,9 +36,9 @@ def test_generate_lifetime_features():
                     'weight',
                     'height',
                     'mem_raw_data',
-                    'pd_weight',
-                    'pd_height',
-                    'pd_raw_data',
+                    # 'pd_weight',
+                    # 'pd_height',
+                    # 'pd_raw_data',
                 ],
             },
             'features': [
@@ -67,6 +67,9 @@ def test_generate_lifetime_features():
         assert set(data_bundle_h5f) == {'features', 'test_filters', 'label',
                                         'test_dict'}
         assert set(data_bundle_h5f['test_filters']) == {'is_in_test_set'}
+        assert set(data_bundle_h5f['test_dict']) == {'comparison'}
+        assert (set(data_bundle_h5f['test_dict/comparison'])
+                == set(bundle_config['structure']['test_dict']['comparison']))
         assert data_bundle_h5f['features'].shape == (6, 12)
 
     os.remove(h5py_hdf_path)

--- a/feagen/tests/test_feature_generator.py
+++ b/feagen/tests/test_feature_generator.py
@@ -8,10 +8,10 @@ from feagen.tools.feagen_runner import feagen_run_with_configs
 
 
 def test_generate_lifetime_features():
-    h5py_hdf_path = mkstemp(suffix=".h5")[1]
-    pandas_hdf_path = mkstemp(suffix=".h5")[1]
-    pickle_dir = mkdtemp()
-    data_bundles_dir = mkdtemp()
+    h5py_hdf_path = mkstemp(prefix="feagen_test_h5py_", suffix=".h5")[1]
+    pandas_hdf_path = mkstemp(prefix="feagen_test_pandas_", suffix=".h5")[1]
+    pickle_dir = mkdtemp(prefix="feagen_test_pickle_")
+    data_bundles_dir = mkdtemp(prefix="feagen_test_bundle_")
 
     global_config = {
         'generator_class': 'feagen.tests.lifetime_feature_generator'
@@ -36,9 +36,9 @@ def test_generate_lifetime_features():
                     'weight',
                     'height',
                     'mem_raw_data',
-                    # 'pd_weight',
-                    # 'pd_height',
-                    # 'pd_raw_data',
+                    'pd_weight',
+                    'pd_height',
+                    'pd_raw_data',
                 ],
             },
             'features': [


### PR DESCRIPTION
1. refactor the bundling code
2. the bundling process is now controlled by `DataHandler`, so you can customize the bundling process in the method `DataHandler.bundle()`
3. breaking change: bundling using `PandasHDFDataHandler` will generate pandas format instead of simple h5py dataset (resolved #48)